### PR TITLE
Add missing wayland packages

### DIFF
--- a/ci/Dockerfile.alpine
+++ b/ci/Dockerfile.alpine
@@ -33,6 +33,10 @@ RUN apk add --no-cache \
         pango-dev \
         valgrind \
         wayland \
+        wayland-dev \
+        wayland-libs-client \
+        wayland-libs-cursor \
+        wayland-libs-server \
         wayland-protocols \
 # Link the compiler libs to the right directory, clang searches them in
 # /usr/lib/clang/9.0.0/lib/linux for some weird reason

--- a/ci/Dockerfile.debian-buster
+++ b/ci/Dockerfile.debian-buster
@@ -16,6 +16,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         libpango1.0-dev \
         librsvg2-common \
         libwayland-bin \
+        libwayland-client0 \
+        libwayland-cursor0 \
+        libwayland-dev \
+        libwayland-server0 \
         libx11-dev \
         libxinerama-dev \
         libxrandr-dev \

--- a/ci/Dockerfile.debian-stretch
+++ b/ci/Dockerfile.debian-stretch
@@ -16,6 +16,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         libpango1.0-dev \
         librsvg2-common \
         libwayland-bin \
+        libwayland-client0 \
+        libwayland-cursor0 \
+        libwayland-dev \
+        libwayland-server0 \
         libx11-dev \
         libxinerama-dev \
         libxrandr-dev \

--- a/ci/Dockerfile.ubuntu-bionic
+++ b/ci/Dockerfile.ubuntu-bionic
@@ -16,6 +16,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         libpango1.0-dev \
         librsvg2-common \
         libwayland-bin \
+        libwayland-client0 \
+        libwayland-cursor0 \
+        libwayland-dev \
+        libwayland-server0 \
         libx11-dev \
         libxinerama-dev \
         libxrandr-dev \

--- a/ci/Dockerfile.ubuntu-focal
+++ b/ci/Dockerfile.ubuntu-focal
@@ -16,6 +16,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         libpango1.0-dev \
         librsvg2-common \
         libwayland-bin \
+        libwayland-client0 \
+        libwayland-cursor0 \
+        libwayland-dev \
+        libwayland-server0 \
         libx11-dev \
         libxinerama-dev \
         libxrandr-dev \

--- a/ci/Dockerfile.ubuntu-xenial
+++ b/ci/Dockerfile.ubuntu-xenial
@@ -16,6 +16,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         libpango1.0-dev \
         librsvg2-common \
         libwayland-bin \
+        libwayland-client0 \
+        libwayland-cursor0 \
+        libwayland-dev \
+        libwayland-server0 \
         libx11-dev \
         libxinerama-dev \
         libxrandr-dev \


### PR DESCRIPTION
I missed some wayland packages in the last PR, as you can see in https://github.com/dunst-project/dunst/pull/781. 

I had trouble building all the images, because it was getting stuck at some downloads. The PR should be fine, though. I checked if all the packages exist. Maybe you could try building it and see if it works on your system?