### PR TITLE
Make sure `doxygen` and `graphviz` are available.

### DIFF
--- a/ci/Dockerfile.alpine
+++ b/ci/Dockerfile.alpine
@@ -10,11 +10,13 @@ RUN apk add --no-cache \
         curl \
         dbus \
         dbus-dev \
+        doxygen \
         findutils \
         gcc \
         git \
         glib \
         glib-dev \
+        graphviz \
         libnotify \
         libnotify-dev \
         librsvg \

--- a/ci/Dockerfile.archlinux
+++ b/ci/Dockerfile.archlinux
@@ -3,9 +3,11 @@ FROM archlinux/base
 RUN pacman -Syu --needed --noconfirm \
       base-devel \
       clang \
+      doxygen \
       gcovr \
       gdk-pixbuf2 \
       git \
+      graphviz \
       libnotify \
       librsvg \
       libxinerama \

--- a/ci/Dockerfile.debian-buster
+++ b/ci/Dockerfile.debian-buster
@@ -8,7 +8,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         clang \
         curl \
         dbus \
+        doxygen \
         git \
+        graphviz \
         lcov \
         libdbus-1-dev \
         libglib2.0-dev \

--- a/ci/Dockerfile.debian-stretch
+++ b/ci/Dockerfile.debian-stretch
@@ -8,7 +8,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         clang \
         curl \
         dbus \
+        doxygen \
         git \
+        graphviz \
         lcov \
         libdbus-1-dev \
         libglib2.0-dev \

--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -5,10 +5,12 @@ RUN true \
         clang \
         dbus-daemon \
         dbus-devel \
+        doxygen \
         @development-tools \
         diffutils \
         findutils \
         glib2-devel \
+        graphviz \
         lcov \
         libnotify-devel \
         librsvg2 \

--- a/ci/Dockerfile.ubuntu-bionic
+++ b/ci/Dockerfile.ubuntu-bionic
@@ -8,7 +8,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         clang \
         curl \
         dbus \
+        doxygen \
         git \
+        graphviz \
         lcov \
         libdbus-1-dev \
         libglib2.0-dev \

--- a/ci/Dockerfile.ubuntu-focal
+++ b/ci/Dockerfile.ubuntu-focal
@@ -8,7 +8,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         clang \
         curl \
         dbus \
+        doxygen \
         git \
+        graphviz \
         lcov \
         libdbus-1-dev \
         libglib2.0-dev \

--- a/ci/Dockerfile.ubuntu-xenial
+++ b/ci/Dockerfile.ubuntu-xenial
@@ -8,7 +8,9 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         clang \
         curl \
         dbus \
+        doxygen \
         git \
+        graphviz \
         lcov \
         libdbus-1-dev \
         libglib2.0-dev \


### PR DESCRIPTION
Necessary for testing the `doc-doxygen` target of dunst.