### PR TITLE
Allow for building with docker alternatives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ DOCKER_REPO_CI?=dunst/ci
 DOCKER_TECHNIQUE?=build
 REPO=./dunst
 CFLAGS?=-Werror
+DOCKER?=docker
 DOCKER_TARGETS?=all dunstify test-valgrind install
 
 # Structure of the makefile
@@ -40,17 +41,17 @@ clean: ci-clean
 # Push all images to docker hub
 ci-push: ${IMG_CI:%=ci-push-%}
 ci-push-%: ci-build-%
-	docker push "${DOCKER_REPO_CI}:${@:ci-push-%=%}"
+	$(DOCKER) push "${DOCKER_REPO_CI}:${@:ci-push-%=%}"
 
 # Pull all images from docker hub
 ci-pull: ${IMG_CI:%=ci-pull-%}
 ci-pull-%:
-	docker pull "${DOCKER_REPO_CI}:${@:ci-pull-%=%}"
+	$(DOCKER) pull "${DOCKER_REPO_CI}:${@:ci-pull-%=%}"
 
 # Build all images locally from the git repository
 ci-build: ${IMG_CI:%=ci-build-%}
 ci-build-%:
-	docker build \
+	$(DOCKER) build \
 		-t "${DOCKER_REPO_CI}:${@:ci-build-%=%}" \
 		-f ci/Dockerfile.${@:ci-build-%=%} \
 		ci
@@ -65,7 +66,7 @@ ci-run-%: ci-${DOCKER_TECHNIQUE}-%
 
 	[ -e "${REPO}" ]
 
-	docker run \
+	$(DOCKER) run \
 		--rm \
 		--hostname "${@:ci-run-%=%}" \
 		-v "$(shell readlink -f ${REPO}):/dunstrepo" \
@@ -80,4 +81,4 @@ ci-run-%: ci-${DOCKER_TECHNIQUE}-%
 # Remove the images from your local docker machine
 ci-clean: ${IMG_CI:%=ci-clean-%}
 ci-clean-%:
-	-docker image rm "${DOCKER_REPO_CI}:${@:ci-clean-%=%}"
+	-$(DOCKER) image rm "${DOCKER_REPO_CI}:${@:ci-clean-%=%}"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Use `make` for this and point the `REPO` variable to your repository. So a `make
 
 If you do not want to build the images, but download the prebuilt ones from dockerhub, add the variable `DOCKER_TECHNIQUE=pull` to your make call.
 
+If you do not use docker but a replacement (with compatible CLI; e.g. [podman](https://github.com/containers/podman)), add the variable `DOCKER=podman` to your make call.
+
 To test dunst in a specific image, use `make ci-run-<image>`.
 
 Example: `make REPO=../dunst.git ci-run-alpine`


### PR DESCRIPTION
`podman` is a CLI compatible drop-in replacement with some benefits compared to `docker`. Make it easy to be used instead of `docker`.