### PR TITLE
Update CI images - part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Example: `make REPO=../dunst.git ci-run-alpine`
 - Alpine Latest (`alpine`)
 - Debian Stretch (`debian-stretch`)
 - Debian Buster (`debian-buster`)
-- Fedora 30 (`fedora30`)
+- Fedora 39 (`fedora39`)
 - Ubuntu 16.04 (`ubuntu-xenial`)
 - Ubuntu 18.04 (`ubuntu-bionic`)
 - Ubuntu 20.04 (`ubuntu-focal`)

--- a/ci/Dockerfile.alpine
+++ b/ci/Dockerfile.alpine
@@ -1,16 +1,18 @@
-FROM alpine:3.11
+FROM alpine:3.18
 
 RUN apk add --no-cache \
         bash \
         cairo \
         cairo-dev \
         clang \
-        compiler-rt \
-        compiler-rt-static \
         curl \
         dbus \
         dbus-dev \
         findutils \
+        # it seems like some font needs to be available for pango to properly
+        # work - otherwise valgrind complains about jumps depending on
+        # uninitialized values
+        font-dejavu \
         gcc \
         git \
         glib \
@@ -28,7 +30,6 @@ RUN apk add --no-cache \
         libxscrnsaver-dev \
         make \
         musl-dev \
-        openssh-client \
         pango \
         pango-dev \
         valgrind \
@@ -38,10 +39,6 @@ RUN apk add --no-cache \
         wayland-libs-cursor \
         wayland-libs-server \
         wayland-protocols \
-# Link the compiler libs to the right directory, clang searches them in
-# /usr/lib/clang/9.0.0/lib/linux for some weird reason
- && mkdir /usr/lib/clang/9.0.0/lib/ \
- && ln -sT /usr/lib/clang/9.0.0/ /usr/lib/clang/9.0.0/lib/linux \
  && true
 
 RUN set -ex; \

--- a/ci/Dockerfile.archlinux
+++ b/ci/Dockerfile.archlinux
@@ -1,7 +1,6 @@
-FROM archlinux/base
+FROM archlinux:base-devel
 
 RUN pacman -Syu --needed --noconfirm \
-      base-devel \
       clang \
       gcovr \
       gdk-pixbuf2 \
@@ -12,21 +11,21 @@ RUN pacman -Syu --needed --noconfirm \
       libxrandr \
       libxss \
       pango \
-      perl \
       valgrind \
       wayland \
       wayland-protocols \
+      lcov \
+      # it seems like some font needs to be available for pango to properly
+      # work - otherwise valgrind complains about jumps depending on
+      # uninitialized values
+      ttf-dejavu \
  && true
 
 RUN ln -sT /usr/bin/core_perl/pod2man /usr/bin/pod2man
 
-RUN set -ex; \
-    . /etc/profile; \
-    cpan -i PerlIO::gzip JSON; \
-    git clone https://github.com/linux-test-project/lcov.git; \
-    make -C lcov -j install; \
-    rm lcov -rf; \
-    :;
+# Normally, re-login would trigger a source of /etc/profile.d/debuginfod.sh.
+# This won't happen here so we just set it up manually.
+ENV DEBUGINFOD_URLS="https://debuginfod.archlinux.org"
 
 ADD entrypoint.sh /srv/entrypoint
 

--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM fedora:39
 
 RUN true \
  && dnf install -y \


### PR DESCRIPTION
This updates CI images based for Alpine, Archlinux, and Fedora. For them to successfully compile, [compiler warnings need to be fixed](https://github.com/dunst-project/dunst/pull/1232).