### PR TITLE
Fix coverage builds on Debian bookworm

### DIFF
--- a/ci/Dockerfile.debian-bookworm
+++ b/ci/Dockerfile.debian-bookworm
@@ -6,6 +6,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         build-essential \
         ca-certificates \
         clang \
+        libclang-rt-dev \
         curl \
         dbus \
         git \


### PR DESCRIPTION
This just adds some missing libraries to get the `test-coverage` target working.