### PR TITLE
Update Fedora and add Ubuntu Noble Numbat

### DIFF
--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -1,7 +1,6 @@
-FROM fedora:39
+FROM fedora:40
 
-RUN true \
- && dnf install -y \
+RUN dnf install -y \
         clang \
         dbus-daemon \
         dbus-devel \
@@ -20,8 +19,7 @@ RUN true \
         pango-devel \
         valgrind \
         wayland-devel \
-        wayland-protocols-devel \
- && true
+        wayland-protocols-devel
 
 ADD entrypoint.sh /srv/entrypoint
 

--- a/ci/Dockerfile.ubuntu-noble
+++ b/ci/Dockerfile.ubuntu-noble
@@ -1,0 +1,33 @@
+FROM ubuntu:noble
+
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        clang \
+        curl \
+        dbus \
+        git \
+        lcov \
+        libdbus-1-dev \
+        libglib2.0-dev \
+        libnotify-dev \
+        libpango1.0-dev \
+        librsvg2-common \
+        libwayland-bin \
+        libwayland-client0 \
+        libwayland-cursor0 \
+        libwayland-dev \
+        libwayland-server0 \
+        libx11-dev \
+        libxinerama-dev \
+        libxrandr-dev \
+        libxss-dev \
+        valgrind \
+        wayland-protocols \
+ && apt-get clean
+
+ADD entrypoint.sh /srv/entrypoint
+
+ENTRYPOINT ["/srv/entrypoint"]


### PR DESCRIPTION
* Fedora 40 was released on April 23rd and will replace 39 for our builds.
* Ubuntu 24.04 (Code name Noble Numbat) is the latest LTS release (released on April 25th) and will be added to the test matrix.