### PR TITLE
Rebuild images once a month

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,10 @@
 name: Build dunst CI images
 
-# Run only when merged onto master
+# Run only when merged onto master or once a month in order to get latest
+# packages for each distribution.
 on:
+  schedule:
+    - cron: "42 3 15 * *"
   push:
     branches: [ 'master' ]
   workflow_dispatch:


### PR DESCRIPTION
Additionally to manually triggering the pipeline to rebuild all images, we can also do it once a month to get the latest packages. This is especially beneficial on a rolling release distribution as Arch Linux.